### PR TITLE
Add carousel to Projects page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-i18next": "^13.5.0",
+        "react-responsive-carousel": "^3.2.23",
         "react-router-dom": "^6.18.0"
       },
       "devDependencies": {
@@ -1849,6 +1850,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -3860,7 +3867,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4356,7 +4362,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -4420,6 +4425,18 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-easy-swipe": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/react-easy-swipe/-/react-easy-swipe-0.0.21.tgz",
+      "integrity": "sha512-OeR2jAxdoqUMHIn/nS9fgreI5hSpgGoL5ezdal4+oO7YSSgJR8ga+PkYGJrSrJ9MKlPcQjMQXnketrD7WNmNsg==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.5.8"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/react-i18next": {
       "version": "13.5.0",
       "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-13.5.0.tgz",
@@ -4446,7 +4463,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-refresh": {
@@ -4457,6 +4473,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-responsive-carousel": {
+      "version": "3.2.23",
+      "resolved": "https://registry.npmjs.org/react-responsive-carousel/-/react-responsive-carousel-3.2.23.tgz",
+      "integrity": "sha512-pqJLsBaKHWJhw/ItODgbVoziR2z4lpcJg+YwmRlSk4rKH32VE633mAtZZ9kDXjy4wFO+pgUZmDKPsPe1fPmHCg==",
+      "license": "MIT",
+      "dependencies": {
+        "classnames": "^2.2.5",
+        "prop-types": "^15.5.8",
+        "react-easy-swipe": "^0.0.21"
       }
     },
     "node_modules/react-router": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-i18next": "^13.5.0",
+    "react-responsive-carousel": "^3.2.23",
     "react-router-dom": "^6.18.0"
   },
   "devDependencies": {

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,5 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@import 'react-responsive-carousel/lib/styles/carousel.min.css';

--- a/src/pages/Projects.jsx
+++ b/src/pages/Projects.jsx
@@ -1,11 +1,21 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
+import { Carousel } from 'react-responsive-carousel'
+import 'react-responsive-carousel/lib/styles/carousel.min.css'
+import reposData from '../data/repos_github_for_portfolio.json'
 
 export default function Projects() {
   return (
     <div className="min-h-screen bg-gray-100 p-8">
       <h1 className="text-3xl font-bold mb-4">Projects</h1>
-      <p>This is the Projects page. Add your project details here.</p>
+      <Carousel>
+        {reposData.map((project, index) => (
+          <div key={index}>
+            <img src={project.image_path || "/placeholder.svg?height=200&width=300"} alt={project.name} />
+            <p className="legend">{project.name}</p>
+          </div>
+        ))}
+      </Carousel>
       <Link to="/" className="text-blue-600 hover:underline mt-4 inline-block">Back to Home</Link>
     </div>
   )

--- a/vite.config.js.timestamp-1730111522611-a560862dfc0d9.mjs
+++ b/vite.config.js.timestamp-1730111522611-a560862dfc0d9.mjs
@@ -1,0 +1,13 @@
+// vite.config.js
+import { defineConfig } from "file:///workspaces/portfolio_lv/node_modules/vite/dist/node/index.js";
+import react from "file:///workspaces/portfolio_lv/node_modules/@vitejs/plugin-react/dist/index.mjs";
+var vite_config_default = defineConfig({
+  plugins: [react()],
+  css: {
+    postcss: "./postcss.config.cjs"
+  }
+});
+export {
+  vite_config_default as default
+};
+//# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsidml0ZS5jb25maWcuanMiXSwKICAic291cmNlc0NvbnRlbnQiOiBbImNvbnN0IF9fdml0ZV9pbmplY3RlZF9vcmlnaW5hbF9kaXJuYW1lID0gXCIvd29ya3NwYWNlcy9wb3J0Zm9saW9fbHZcIjtjb25zdCBfX3ZpdGVfaW5qZWN0ZWRfb3JpZ2luYWxfZmlsZW5hbWUgPSBcIi93b3Jrc3BhY2VzL3BvcnRmb2xpb19sdi92aXRlLmNvbmZpZy5qc1wiO2NvbnN0IF9fdml0ZV9pbmplY3RlZF9vcmlnaW5hbF9pbXBvcnRfbWV0YV91cmwgPSBcImZpbGU6Ly8vd29ya3NwYWNlcy9wb3J0Zm9saW9fbHYvdml0ZS5jb25maWcuanNcIjtpbXBvcnQgeyBkZWZpbmVDb25maWcgfSBmcm9tICd2aXRlJ1xuaW1wb3J0IHJlYWN0IGZyb20gJ0B2aXRlanMvcGx1Z2luLXJlYWN0J1xuXG5leHBvcnQgZGVmYXVsdCBkZWZpbmVDb25maWcoe1xuICBwbHVnaW5zOiBbcmVhY3QoKV0sXG4gIGNzczoge1xuICAgIHBvc3Rjc3M6ICcuL3Bvc3Rjc3MuY29uZmlnLmNqcycsXG4gIH0sXG59KSJdLAogICJtYXBwaW5ncyI6ICI7QUFBMFAsU0FBUyxvQkFBb0I7QUFDdlIsT0FBTyxXQUFXO0FBRWxCLElBQU8sc0JBQVEsYUFBYTtBQUFBLEVBQzFCLFNBQVMsQ0FBQyxNQUFNLENBQUM7QUFBQSxFQUNqQixLQUFLO0FBQUEsSUFDSCxTQUFTO0FBQUEsRUFDWDtBQUNGLENBQUM7IiwKICAibmFtZXMiOiBbXQp9Cg==


### PR DESCRIPTION
Add carousel functionality to the Projects page.

* **Projects.jsx**
  - Import `Carousel` component from `react-responsive-carousel`.
  - Import carousel styles from `react-responsive-carousel/lib/styles/carousel.min.css`.
  - Replace static paragraph with a `Carousel` component.
  - Map over `reposData` to create `Carousel` items with project images and names.

* **index.css**
  - Import carousel styles from `react-responsive-carousel/lib/styles/carousel.min.css`.

* **package.json**
  - Add `react-responsive-carousel` dependency.

* **package-lock.json**
  - Add `react-responsive-carousel` and its dependencies.

