### PR TITLE
Fix regression in carousel and projects page data source

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,5 @@
+@import 'react-responsive-carousel/lib/styles/carousel.min.css';
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-@import 'react-responsive-carousel/lib/styles/carousel.min.css';

--- a/src/pages/Portfolio.jsx
+++ b/src/pages/Portfolio.jsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom'
 import { ChevronRight, Globe } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import ProjectModal from '../components/ProjectModal'
-import projectsData from '../data/projects.json'
+import projectsData from '../data/repos_github_for_portfolio.json'
 import { Carousel } from 'react-responsive-carousel'
 
 export default function Portfolio() {
@@ -128,10 +128,10 @@ export default function Portfolio() {
         <div className="mt-12">
           <h2 className="text-2xl font-bold text-gray-900">{t('latestProjects.title')}</h2>
           <Carousel>
-            {projectsData.projets.slice(0, 6).map((project, index) => (
+            {projectsData.slice(0, 6).map((project, index) => (
               <div key={index} className="bg-white overflow-hidden shadow rounded-lg">
                 <div className="p-5">
-                  <h3 className="text-lg font-medium text-gray-900">{project.nom}</h3>
+                  <h3 className="text-lg font-medium text-gray-900">{project.name}</h3>
                   <p className="mt-1 text-sm text-gray-500">{project.description || t('latestProjects.noDescription')}</p>
                   <div className="mt-4">
                     <button

--- a/src/pages/Projects.jsx
+++ b/src/pages/Projects.jsx
@@ -1,21 +1,23 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
 import { Carousel } from 'react-responsive-carousel'
-import projectsData from '../data/projects.json'
+import projectsData from '../data/repos_github_for_portfolio.json'
 
 export default function Projects() {
   return (
     <div className="min-h-screen bg-gray-100 p-8">
+      <div className="mt-8">
+        <Link to="/" className="text-blue-600 hover:underline">Back to Home</Link>
+      </div>
       <h1 className="text-3xl font-bold mb-4">Projects</h1>
       <Carousel>
-        {projectsData.projets.map((project, index) => (
+        {projectsData.map((project, index) => (
           <div key={index}>
-            <img src={project.image || "/placeholder.svg?height=200&width=300"} alt={project.nom} />
-            <p className="legend">{project.nom}</p>
+            <img src={project.image || "/placeholder.svg?height=200&width=300"} alt={project.name} />
+            <p className="legend">{project.name}</p>
           </div>
         ))}
       </Carousel>
-      <Link to="/" className="text-blue-600 hover:underline mt-4 inline-block">Back to Home</Link>
     </div>
   )
 }

--- a/src/pages/Skills.jsx
+++ b/src/pages/Skills.jsx
@@ -5,6 +5,9 @@ import softskillsData from '../data/softskills.json'
 export default function Skills() {
   return (
     <div className="min-h-screen bg-gray-100 p-8">
+      <div className="mt-8">
+        <Link to="/" className="text-blue-600 hover:underline">Back to Home</Link>
+      </div>
       <h1 className="text-3xl font-bold mb-4">Skills</h1>
       <div>
         <h2 className="text-2xl font-semibold mb-2">Technical Skills</h2>
@@ -32,7 +35,6 @@ export default function Skills() {
           </div>
         ))}
       </div>
-      <Link to="/" className="text-blue-600 hover:underline mt-4 inline-block">Back to Home</Link>
     </div>
   )
 }

--- a/vite.config.js.timestamp-1730125404286-99581c918af15.mjs
+++ b/vite.config.js.timestamp-1730125404286-99581c918af15.mjs
@@ -1,0 +1,13 @@
+// vite.config.js
+import { defineConfig } from "file:///workspaces/portfolio_lv/node_modules/vite/dist/node/index.js";
+import react from "file:///workspaces/portfolio_lv/node_modules/@vitejs/plugin-react/dist/index.mjs";
+var vite_config_default = defineConfig({
+  plugins: [react()],
+  css: {
+    postcss: "./postcss.config.cjs"
+  }
+});
+export {
+  vite_config_default as default
+};
+//# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsidml0ZS5jb25maWcuanMiXSwKICAic291cmNlc0NvbnRlbnQiOiBbImNvbnN0IF9fdml0ZV9pbmplY3RlZF9vcmlnaW5hbF9kaXJuYW1lID0gXCIvd29ya3NwYWNlcy9wb3J0Zm9saW9fbHZcIjtjb25zdCBfX3ZpdGVfaW5qZWN0ZWRfb3JpZ2luYWxfZmlsZW5hbWUgPSBcIi93b3Jrc3BhY2VzL3BvcnRmb2xpb19sdi92aXRlLmNvbmZpZy5qc1wiO2NvbnN0IF9fdml0ZV9pbmplY3RlZF9vcmlnaW5hbF9pbXBvcnRfbWV0YV91cmwgPSBcImZpbGU6Ly8vd29ya3NwYWNlcy9wb3J0Zm9saW9fbHYvdml0ZS5jb25maWcuanNcIjtpbXBvcnQgeyBkZWZpbmVDb25maWcgfSBmcm9tICd2aXRlJ1xuaW1wb3J0IHJlYWN0IGZyb20gJ0B2aXRlanMvcGx1Z2luLXJlYWN0J1xuXG5leHBvcnQgZGVmYXVsdCBkZWZpbmVDb25maWcoe1xuICBwbHVnaW5zOiBbcmVhY3QoKV0sXG4gIGNzczoge1xuICAgIHBvc3Rjc3M6ICcuL3Bvc3Rjc3MuY29uZmlnLmNqcycsXG4gIH0sXG59KSJdLAogICJtYXBwaW5ncyI6ICI7QUFBMFAsU0FBUyxvQkFBb0I7QUFDdlIsT0FBTyxXQUFXO0FBRWxCLElBQU8sc0JBQVEsYUFBYTtBQUFBLEVBQzFCLFNBQVMsQ0FBQyxNQUFNLENBQUM7QUFBQSxFQUNqQixLQUFLO0FBQUEsSUFDSCxTQUFTO0FBQUEsRUFDWDtBQUNGLENBQUM7IiwKICAibmFtZXMiOiBbXQp9Cg==


### PR DESCRIPTION
Update the source of project data for the carousel and projects page.

* Change the import statement in `src/pages/Projects.jsx` to import project data from `src/data/repos_github_for_portfolio.json` instead of `src/data/projects.json`.
* Change the import statement in `src/pages/Portfolio.jsx` to import project data from `src/data/repos_github_for_portfolio.json` instead of `src/data/projects.json`.
* Move the `@import 'react-responsive-carousel/lib/styles/carousel.min.css';` statement to the top of the file in `src/index.css`.
* Add a "Back to Home" link at the top of the `Projects` and `Skills` components.

