### PR TITLE
Add view details button and modal view to projects page carousel

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -3,3 +3,8 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* Add CSS for opacity on hover for project images */
+img:hover {
+  opacity: 0.75;
+}

--- a/src/pages/Projects.jsx
+++ b/src/pages/Projects.jsx
@@ -1,9 +1,23 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { Link } from 'react-router-dom'
 import { Carousel } from 'react-responsive-carousel'
 import projectsData from '../data/repos_github_for_portfolio.json'
+import ProjectModal from '../components/ProjectModal'
 
 export default function Projects() {
+  const [modalOpen, setModalOpen] = useState(false)
+  const [selectedProject, setSelectedProject] = useState(null)
+
+  const openModal = (project) => {
+    setSelectedProject(project)
+    setModalOpen(true)
+  }
+
+  const closeModal = () => {
+    setModalOpen(false)
+    setSelectedProject(null)
+  }
+
   return (
     <div className="min-h-screen bg-gray-100 p-8">
       <div className="mt-8">
@@ -12,12 +26,22 @@ export default function Projects() {
       <h1 className="text-3xl font-bold mb-4">Projects</h1>
       <Carousel>
         {projectsData.map((project, index) => (
-          <div key={index}>
-            <img src={project.image_path || "/placeholder.svg?height=200&width=300"} alt={project.name} />
+          <div key={index} className="relative">
+            <img src={project.image_path || "/placeholder.svg?height=200&width=300"} alt={project.name} className="hover:opacity-75" />
             <p className="legend">{project.name}</p>
+            <button
+              onClick={() => openModal(project)}
+              className="absolute bottom-4 left-1/2 transform -translate-x-1/2 px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-blue-700 bg-blue-100 hover:bg-blue-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+            >
+              View Details
+            </button>
           </div>
         ))}
       </Carousel>
+
+      {modalOpen && selectedProject && (
+        <ProjectModal project={selectedProject} onClose={closeModal} />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
Add 'view details' button and modal view to projects page carousel, and add opacity on hover for project images.

* **Projects Page Carousel:**
  - Add 'view details' button to each project in the carousel in `src/pages/Projects.jsx`.
  - Implement `openModal` and `closeModal` functions to handle modal view.
  - Add state variables `modalOpen` and `selectedProject`.
  - Add `ProjectModal` component to render the modal view.

* **CSS:**
  - Add CSS for opacity on hover for project images in `src/index.css`.

