### PR TITLE
Fix modal on projects page to display details

### DIFF
--- a/src/components/ProjectModal.jsx
+++ b/src/components/ProjectModal.jsx
@@ -62,7 +62,7 @@ export default function ProjectModal({ project, onClose }) {
           </div>
           <div className="bg-gray-50 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
             <a
-              href={project.url}
+              href={project.repo_url}
               target="_blank"
               rel="noopener noreferrer"
               className="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-blue-600 text-base font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 sm:ml-3 sm:w-auto sm:text-sm"

--- a/src/data/repos_github_for_portfolio.json
+++ b/src/data/repos_github_for_portfolio.json
@@ -36,9 +36,9 @@
       },
       "modernity_score": 100.0
     },
-    "url": "https://github.com/kydoCode/24hour_integrationChalllenge",
+    "repo_url": "https://github.com/kydoCode/24hour_integrationChalllenge",
     "image_path": "./src/assets/images/projects/24hour_integrationChalllenge.png",
-    "avatar_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
+    "site_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
   },
   {
     "name": "Délices sucrés",
@@ -73,9 +73,9 @@
       },
       "modernity_score": 100.0
     },
-    "url": "https://github.com/kydoCode/24hour_integrationChalllenge_projecttwo",
+    "repo_url": "https://github.com/kydoCode/24hour_integrationChalllenge_projecttwo",
     "image_path": "./src/assets/images/projects/24hour_integrationChalllenge_projecttwo.png",
-    "avatar_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
+    "site_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
   },
   {
     "name": "BookAPI",
@@ -105,9 +105,9 @@
       "html_versions": {},
       "modernity_score": 0
     },
-    "url": "https://github.com/kydoCode/BookAPI",
+    "repo_url": "https://github.com/kydoCode/BookAPI",
     "image_path": "/images/BookAPI.png",
-    "avatar_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
+    "site_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
   },
   {
     "name": "brigitte_artgalery_clone",
@@ -154,9 +154,9 @@
       },
       "modernity_score": 100.0
     },
-    "url": "https://github.com/kydoCode/brigitte_artgalery_clone",
+    "repo_url": "https://github.com/kydoCode/brigitte_artgalery_clone",
     "image_path": "./src/assets/images/projects/brigitte_artgalery_clone.png",
-    "avatar_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
+    "site_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
   },
   {
     "name": "cookie_cookie",
@@ -181,9 +181,9 @@
       },
       "modernity_score": 100.0
     },
-    "url": "https://github.com/kydoCode/cookie_cookie",
+    "repo_url": "https://github.com/kydoCode/cookie_cookie",
     "image_path": "./src/assets/images/projects/cookie_cookie.png",
-    "avatar_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
+    "site_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
   },
   {
     "name": "fonciere_pagerie_malmaison_assignment",
@@ -222,9 +222,9 @@
       },
       "modernity_score": 100.0
     },
-    "url": "https://github.com/kydoCode/fonciere_pagerie_malmaison_assignment",
+    "repo_url": "https://github.com/kydoCode/fonciere_pagerie_malmaison_assignment",
     "image_path": "/images/fonciere_pagerie_malmaison_assignment.png",
-    "avatar_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
+    "site_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
   },
   {
     "name": "GeniArtHub",
@@ -268,9 +268,9 @@
       },
       "modernity_score": 100.0
     },
-    "url": "https://github.com/kydoCode/GeniArtHub",
+    "repo_url": "https://github.com/kydoCode/GeniArtHub",
     "image_path": "/images/GeniArtHub.png",
-    "avatar_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
+    "site_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
   },
   {
     "name": "GeniArtHub-react-refactor",
@@ -320,9 +320,9 @@
       },
       "modernity_score": 100.0
     },
-    "url": "https://github.com/kydoCode/GeniArtHub-react-refactor",
+    "repo_url": "https://github.com/kydoCode/GeniArtHub-react-refactor",
     "image_path": "./src/assets/images/projects/GeniArtHub-react-refactor.png",
-    "avatar_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
+    "site_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
   },
   {
     "name": "hagile_clone",
@@ -360,9 +360,9 @@
       },
       "modernity_score": 100.0
     },
-    "url": "https://github.com/kydoCode/hagile_clone",
+    "repo_url": "https://github.com/kydoCode/hagile_clone",
     "image_path": "/images/hagile_clone.png",
-    "avatar_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
+    "site_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
   },
   {
     "name": "Home-Key",
@@ -395,9 +395,9 @@
       },
       "modernity_score": 100.0
     },
-    "url": "https://github.com/kydoCode/Home-Key",
+    "repo_url": "https://github.com/kydoCode/Home-Key",
     "image_path": "/images/Home-Key.png",
-    "avatar_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
+    "site_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
   },
   {
     "name": "Home-Key-v2",
@@ -435,9 +435,9 @@
       },
       "modernity_score": 100.0
     },
-    "url": "https://github.com/kydoCode/Home-Key-v2",
+    "repo_url": "https://github.com/kydoCode/Home-Key-v2",
     "image_path": "./src/assets/images/projects/homekeyv2.png",
-    "avatar_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
+    "site_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
   },
   {
     "name": "my_portfolio",
@@ -470,9 +470,9 @@
       },
       "modernity_score": 100.0
     },
-    "url": "https://github.com/kydoCode/my_portfolio",
+    "repo_url": "https://github.com/kydoCode/my_portfolio",
     "image_path": "/images/my_portfolio.png",
-    "avatar_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
+    "site_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
   },
   {
     "name": "oraculus",
@@ -508,9 +508,9 @@
       },
       "modernity_score": 100.0
     },
-    "url": "https://github.com/kydoCode/oraculus",
+    "repo_url": "https://github.com/kydoCode/oraculus",
     "image_path": "./src/assets/images/projects/oraculus.png",
-    "avatar_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
+    "site_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
   },
   {
     "name": "oraculus-react-version",
@@ -556,9 +556,9 @@
       },
       "modernity_score": 100.0
     },
-    "url": "https://github.com/kydoCode/oraculus-react-version",
+    "repo_url": "https://github.com/kydoCode/oraculus-react-version",
     "image_path": "/images/oraculus-react-version.png",
-    "avatar_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
+    "site_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
   },
   {
     "name": "skillfacile-add-dom-events",
@@ -583,9 +583,9 @@
       },
       "modernity_score": 100.0
     },
-    "url": "https://github.com/kydoCode/skillfacile-add-dom-events",
+    "repo_url": "https://github.com/kydoCode/skillfacile-add-dom-events",
     "image_path": "./src/assets/images/projects/skillfacile-add-dom-events.png",
-    "avatar_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
+    "site_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
   },
   {
     "name": "skillfacile_clone",
@@ -623,9 +623,9 @@
       },
       "modernity_score": 100.0
     },
-    "url": "https://github.com/kydoCode/skillfacile_clone",
+    "repo_url": "https://github.com/kydoCode/skillfacile_clone",
     "image_path": "/images/skillfacile_clone.png",
-    "avatar_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
+    "site_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
   },
   {
     "name": "vividly",
@@ -656,8 +656,8 @@
       },
       "modernity_score": 100.0
     },
-    "url": "https://github.com/kydoCode/vividly",
+    "repo_url": "https://github.com/kydoCode/vividly",
     "image_path": "/images/vividly.png",
-    "avatar_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
+    "site_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
   }
 ]


### PR DESCRIPTION
Update modal to display project details correctly on the projects page.

* **Update `repos_github_for_portfolio.json`**:
  - Replace all `avatar_url` fields with `site_url`.
  - Rename all `url` fields to `repo_url`.

* **Update `ProjectModal.jsx`**:
  - Update `href` attribute of the GitHub link to use `project.repo_url` instead of `project.url`.

