### PR TITLE
Fix images not displaying on GitHub Pages

### DIFF
--- a/src/data/repos_github_for_portfolio.json
+++ b/src/data/repos_github_for_portfolio.json
@@ -37,7 +37,7 @@
       "modernity_score": 100.0
     },
     "repo_url": "https://github.com/kydoCode/24hour_integrationChalllenge",
-    "image_path": "./src/assets/images/projects/24hour_integrationChalllenge.png",
+    "image_path": "https://kydoCode.github.io/portfolio_lv/src/assets/images/projects/24hour_integrationChalllenge.png",
     "site_url": "https://kydocode.github.io/24hour_integrationChalllenge/"
   },
   {
@@ -74,7 +74,7 @@
       "modernity_score": 100.0
     },
     "repo_url": "https://github.com/kydoCode/24hour_integrationChalllenge_projecttwo",
-    "image_path": "./src/assets/images/projects/24hour_integrationChalllenge_projecttwo.png",
+    "image_path": "https://kydoCode.github.io/portfolio_lv/src/assets/images/projects/24hour_integrationChalllenge_projecttwo.png",
     "site_url": "https://kydocode.github.io/24hour_integrationChalllenge_projecttwo/"
   },
   {
@@ -106,7 +106,7 @@
       "modernity_score": 0
     },
     "repo_url": "https://github.com/kydoCode/BookAPI",
-    "image_path": "/images/BookAPI.png",
+    "image_path": "https://kydoCode.github.io/portfolio_lv/images/BookAPI.png",
     "site_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
   },
   {
@@ -155,7 +155,7 @@
       "modernity_score": 100.0
     },
     "repo_url": "https://github.com/kydoCode/brigitte_artgalery_clone",
-    "image_path": "./src/assets/images/projects/brigitte_artgalery_clone.png",
+    "image_path": "https://kydoCode.github.io/portfolio_lv/src/assets/images/projects/brigitte_artgalery_clone.png",
     "site_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
   },
   {
@@ -182,7 +182,7 @@
       "modernity_score": 100.0
     },
     "repo_url": "https://github.com/kydoCode/cookie_cookie",
-    "image_path": "./src/assets/images/projects/cookie_cookie.png",
+    "image_path": "https://kydoCode.github.io/portfolio_lv/src/assets/images/projects/cookie_cookie.png",
     "site_url": "https://kydocode.github.io/cookie_cookie/"
   },
   {
@@ -223,7 +223,7 @@
       "modernity_score": 100.0
     },
     "repo_url": "https://github.com/kydoCode/fonciere_pagerie_malmaison_assignment",
-    "image_path": "/images/fonciere_pagerie_malmaison_assignment_01.png",
+    "image_path": "https://kydoCode.github.io/portfolio_lv/images/fonciere_pagerie_malmaison_assignment_01.png",
     "site_url": "https://kydocode.github.io/fonciere_pagerie_malmaison_assignment/"
   },
   {
@@ -269,7 +269,7 @@
       "modernity_score": 100.0
     },
     "repo_url": "https://github.com/kydoCode/GeniArtHub",
-    "image_path": "/images/GeniArtHub.png",
+    "image_path": "https://kydoCode.github.io/portfolio_lv/images/GeniArtHub.png",
     "site_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
   },
   {
@@ -321,7 +321,7 @@
       "modernity_score": 100.0
     },
     "repo_url": "https://github.com/kydoCode/GeniArtHub-react-refactor",
-    "image_path": "./src/assets/images/projects/GeniArtHub-react-refactor.png",
+    "image_path": "https://kydoCode.github.io/portfolio_lv/src/assets/images/projects/GeniArtHub-react-refactor.png",
     "site_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
   },
   {
@@ -361,7 +361,7 @@
       "modernity_score": 100.0
     },
     "repo_url": "https://github.com/kydoCode/hagile_clone",
-    "image_path": "/images/hagile_clone.png",
+    "image_path": "https://kydoCode.github.io/portfolio_lv/images/hagile_clone.png",
     "site_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
   },
   {
@@ -396,7 +396,7 @@
       "modernity_score": 100.0
     },
     "repo_url": "https://github.com/kydoCode/Home-Key",
-    "image_path": "/images/Home-Key.png",
+    "image_path": "https://kydoCode.github.io/portfolio_lv/images/Home-Key.png",
     "site_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
   },
   {
@@ -436,7 +436,7 @@
       "modernity_score": 100.0
     },
     "repo_url": "https://github.com/kydoCode/Home-Key-v2",
-    "image_path": "./src/assets/images/projects/homekeyv2.png",
+    "image_path": "https://kydoCode.github.io/portfolio_lv/src/assets/images/projects/homekeyv2.png",
     "site_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
   },
   {
@@ -471,7 +471,7 @@
       "modernity_score": 100.0
     },
     "repo_url": "https://github.com/kydoCode/my_portfolio",
-    "image_path": "/images/my_portfolio.png",
+    "image_path": "https://kydoCode.github.io/portfolio_lv/images/my_portfolio.png",
     "site_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
   },
   {
@@ -509,7 +509,7 @@
       "modernity_score": 100.0
     },
     "repo_url": "https://github.com/kydoCode/oraculus",
-    "image_path": "./src/assets/images/projects/oraculus.png",
+    "image_path": "https://kydoCode.github.io/portfolio_lv/src/assets/images/projects/oraculus.png",
     "site_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
   },
   {
@@ -557,7 +557,7 @@
       "modernity_score": 100.0
     },
     "repo_url": "https://github.com/kydoCode/oraculus-react-version",
-    "image_path": "/images/oraculus-react-version.png",
+    "image_path": "https://kydoCode.github.io/portfolio_lv/images/oraculus-react-version.png",
     "site_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
   },
   {
@@ -584,7 +584,7 @@
       "modernity_score": 100.0
     },
     "repo_url": "https://github.com/kydoCode/skillfacile-add-dom-events",
-    "image_path": "./src/assets/images/projects/skillfacile-add-dom-events.png",
+    "image_path": "https://kydoCode.github.io/portfolio_lv/src/assets/images/projects/skillfacile-add-dom-events.png",
     "site_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
   },
   {
@@ -624,7 +624,7 @@
       "modernity_score": 100.0
     },
     "repo_url": "https://github.com/kydoCode/skillfacile_clone",
-    "image_path": "/images/skillfacile_clone.png",
+    "image_path": "https://kydoCode.github.io/portfolio_lv/images/skillfacile_clone.png",
     "site_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
   },
   {
@@ -657,7 +657,7 @@
       "modernity_score": 100.0
     },
     "repo_url": "https://github.com/kydoCode/vividly",
-    "image_path": "/images/vividly.png",
+    "image_path": "https://kydoCode.github.io/portfolio_lv/images/vividly.png",
     "site_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
   }
 ]

--- a/src/pages/Portfolio.jsx
+++ b/src/pages/Portfolio.jsx
@@ -75,7 +75,7 @@ export default function Portfolio() {
         <div className="bg-white rounded-lg shadow-xl overflow-hidden">
           <div className="md:flex">
             <div className="md:flex-shrink-0">
-              <img className="h-full w-full object-cover md:w-48" src="../src/assets/images/avatars/avatar-homepage.jpeg" alt="Profile" />
+              <img className="h-full w-full object-cover md:w-48" src="https://kydoCode.github.io/portfolio_lv/src/assets/images/avatars/avatar-homepage.jpeg" alt="Profile" />
             </div>
             <div className="p-8">
               <div className="text-sm font-semibold text-blue-600">{t('hero.subtitle')}</div>

--- a/src/pages/Projects.jsx
+++ b/src/pages/Projects.jsx
@@ -28,7 +28,7 @@ export default function Projects() {
         {projectsData.map((project, index) => (
           <div key={index} className="relative">
             <img 
-              src={project.image_path || "/placeholder.svg?height=200&width=300"} 
+              src={project.image_path} 
               alt={project.name} 
               className="hover:opacity-75" 
               onClick={() => openModal(project)} 


### PR DESCRIPTION
Update image paths to display correctly on GitHub Pages.

* **src/data/repos_github_for_portfolio.json**
  - Update image paths to be absolute URLs pointing to the GitHub Pages site.

* **src/pages/Portfolio.jsx**
  - Correct the image path for the profile picture to an absolute URL.

* **src/pages/Projects.jsx**
  - Correct the image paths for project images to use the absolute URLs from the JSON data.

