### PR TITLE
Add header, footer components and lucide icons

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Github, Linkedin } from 'lucide-react';
+
+export default function Footer() {
+  return (
+    <footer className="bg-gray-800 text-white py-4">
+      <div className="container mx-auto flex justify-between items-center">
+        <div className="flex items-center space-x-4">
+          <a href="https://github.com/kydoCode" target="_blank" rel="noopener noreferrer">
+            <Github className="h-6 w-6 text-white" />
+          </a>
+          <a href="https://linkedin.com/in/sylvain-clement" target="_blank" rel="noopener noreferrer">
+            <Linkedin className="h-6 w-6 text-white" />
+          </a>
+        </div>
+        <div className="text-sm">
+          2024 - Sylvain CLEMENT - All rights reserved
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Globe } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+export default function Header() {
+  const { t, i18n } = useTranslation();
+
+  const changeLanguage = (lng) => {
+    i18n.changeLanguage(lng);
+  };
+
+  return (
+    <header className="bg-white shadow-sm">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex justify-between items-center py-4">
+          <div className="flex items-center">
+            <span className="text-xl font-bold text-gray-800">{t('header.title')}</span>
+          </div>
+          <nav className="hidden md:flex space-x-8">
+            {['Home', 'Projects', 'Skills', 'Experience', 'Creations', 'Education', 'Hobbies', 'About', 'Contact'].map((item) => (
+              <Link
+                key={item}
+                to={item === 'Home' ? '/' : `/${item.toLowerCase()}`}
+                className="text-gray-500 hover:text-gray-900"
+              >
+                {t(`nav.${item.toLowerCase()}`)}
+              </Link>
+            ))}
+          </nav>
+          <div className="flex items-center">
+            <Globe className="h-5 w-5 text-gray-400 mr-2" />
+            <select
+              onChange={(e) => changeLanguage(e.target.value)}
+              className="bg-white border-gray-300 rounded-md text-gray-700 text-sm"
+            >
+              <option value="en">English</option>
+              <option value="fr">Français</option>
+              <option value="de">Deutsch</option>
+              <option value="zh">中文</option>
+            </select>
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/data/repos_github_for_portfolio.json
+++ b/src/data/repos_github_for_portfolio.json
@@ -37,7 +37,7 @@
       "modernity_score": 100.0
     },
     "repo_url": "https://github.com/kydoCode/24hour_integrationChalllenge",
-    "image_path": "./src/assets/images/projects/24hour_integrationChalllenge.png",
+    "image_path": "https://kydoCode.github.io/portfolio_lv/src/assets/images/projects/24hour_integrationChalllenge.png",
     "site_url": "https://kydocode.github.io/24hour_integrationChalllenge/"
   },
   {
@@ -74,7 +74,7 @@
       "modernity_score": 100.0
     },
     "repo_url": "https://github.com/kydoCode/24hour_integrationChalllenge_projecttwo",
-    "image_path": "./src/assets/images/projects/24hour_integrationChalllenge_projecttwo.png",
+    "image_path": "https://kydoCode.github.io/portfolio_lv/src/assets/images/projects/24hour_integrationChalllenge_projecttwo.png",
     "site_url": "https://kydocode.github.io/24hour_integrationChalllenge_projecttwo/"
   },
   {
@@ -106,7 +106,7 @@
       "modernity_score": 0
     },
     "repo_url": "https://github.com/kydoCode/BookAPI",
-    "image_path": "/images/BookAPI.png",
+    "image_path": "https://kydoCode.github.io/portfolio_lv/images/BookAPI.png",
     "site_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
   },
   {
@@ -155,7 +155,7 @@
       "modernity_score": 100.0
     },
     "repo_url": "https://github.com/kydoCode/brigitte_artgalery_clone",
-    "image_path": "./src/assets/images/projects/brigitte_artgalery_clone.png",
+    "image_path": "https://kydoCode.github.io/portfolio_lv/src/assets/images/projects/brigitte_artgalery_clone.png",
     "site_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
   },
   {
@@ -182,7 +182,7 @@
       "modernity_score": 100.0
     },
     "repo_url": "https://github.com/kydoCode/cookie_cookie",
-    "image_path": "./src/assets/images/projects/cookie_cookie.png",
+    "image_path": "https://kydoCode.github.io/portfolio_lv/src/assets/images/projects/cookie_cookie.png",
     "site_url": "https://kydocode.github.io/cookie_cookie/"
   },
   {
@@ -223,7 +223,7 @@
       "modernity_score": 100.0
     },
     "repo_url": "https://github.com/kydoCode/fonciere_pagerie_malmaison_assignment",
-    "image_path": "/images/fonciere_pagerie_malmaison_assignment_01.png",
+    "image_path": "https://kydoCode.github.io/portfolio_lv/images/fonciere_pagerie_malmaison_assignment_01.png",
     "site_url": "https://kydocode.github.io/fonciere_pagerie_malmaison_assignment/"
   },
   {
@@ -269,7 +269,7 @@
       "modernity_score": 100.0
     },
     "repo_url": "https://github.com/kydoCode/GeniArtHub",
-    "image_path": "/images/GeniArtHub.png",
+    "image_path": "https://kydoCode.github.io/portfolio_lv/images/GeniArtHub.png",
     "site_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
   },
   {
@@ -321,7 +321,7 @@
       "modernity_score": 100.0
     },
     "repo_url": "https://github.com/kydoCode/GeniArtHub-react-refactor",
-    "image_path": "./src/assets/images/projects/GeniArtHub-react-refactor.png",
+    "image_path": "https://kydoCode.github.io/portfolio_lv/src/assets/images/projects/GeniArtHub-react-refactor.png",
     "site_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
   },
   {
@@ -361,7 +361,7 @@
       "modernity_score": 100.0
     },
     "repo_url": "https://github.com/kydoCode/hagile_clone",
-    "image_path": "/images/hagile_clone.png",
+    "image_path": "https://kydoCode.github.io/portfolio_lv/images/hagile_clone.png",
     "site_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
   },
   {
@@ -396,7 +396,7 @@
       "modernity_score": 100.0
     },
     "repo_url": "https://github.com/kydoCode/Home-Key",
-    "image_path": "/images/Home-Key.png",
+    "image_path": "https://kydoCode.github.io/portfolio_lv/images/Home-Key.png",
     "site_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
   },
   {
@@ -436,7 +436,7 @@
       "modernity_score": 100.0
     },
     "repo_url": "https://github.com/kydoCode/Home-Key-v2",
-    "image_path": "./src/assets/images/projects/homekeyv2.png",
+    "image_path": "https://kydoCode.github.io/portfolio_lv/src/assets/images/projects/homekeyv2.png",
     "site_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
   },
   {
@@ -471,7 +471,7 @@
       "modernity_score": 100.0
     },
     "repo_url": "https://github.com/kydoCode/my_portfolio",
-    "image_path": "/images/my_portfolio.png",
+    "image_path": "https://kydoCode.github.io/portfolio_lv/images/my_portfolio.png",
     "site_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
   },
   {
@@ -509,7 +509,7 @@
       "modernity_score": 100.0
     },
     "repo_url": "https://github.com/kydoCode/oraculus",
-    "image_path": "./src/assets/images/projects/oraculus.png",
+    "image_path": "https://kydoCode.github.io/portfolio_lv/src/assets/images/projects/oraculus.png",
     "site_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
   },
   {
@@ -557,7 +557,7 @@
       "modernity_score": 100.0
     },
     "repo_url": "https://github.com/kydoCode/oraculus-react-version",
-    "image_path": "/images/oraculus-react-version.png",
+    "image_path": "https://kydoCode.github.io/portfolio_lv/images/oraculus-react-version.png",
     "site_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
   },
   {
@@ -584,7 +584,7 @@
       "modernity_score": 100.0
     },
     "repo_url": "https://github.com/kydoCode/skillfacile-add-dom-events",
-    "image_path": "./src/assets/images/projects/skillfacile-add-dom-events.png",
+    "image_path": "https://kydoCode.github.io/portfolio_lv/src/assets/images/projects/skillfacile-add-dom-events.png",
     "site_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
   },
   {
@@ -624,7 +624,7 @@
       "modernity_score": 100.0
     },
     "repo_url": "https://github.com/kydoCode/skillfacile_clone",
-    "image_path": "/images/skillfacile_clone.png",
+    "image_path": "https://kydoCode.github.io/portfolio_lv/images/skillfacile_clone.png",
     "site_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
   },
   {
@@ -657,7 +657,7 @@
       "modernity_score": 100.0
     },
     "repo_url": "https://github.com/kydoCode/vividly",
-    "image_path": "/images/vividly.png",
+    "image_path": "https://kydoCode.github.io/portfolio_lv/images/vividly.png",
     "site_url": "https://avatars.githubusercontent.com/u/157696416?v=4"
   }
 ]

--- a/src/pages/Portfolio.jsx
+++ b/src/pages/Portfolio.jsx
@@ -1,10 +1,12 @@
 import React, { useState } from 'react'
 import { Link } from 'react-router-dom'
-import { ChevronRight, Globe } from 'lucide-react'
+import { ChevronRight, Globe, Laptop, Code, Briefcase, Palette, GraduationCap, Heart, User, Mail } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import ProjectModal from '../components/ProjectModal'
 import projectsData from '../data/repos_github_for_portfolio.json'
 import { Carousel } from 'react-responsive-carousel'
+import Header from '../components/Header'
+import Footer from '../components/Footer'
 
 export default function Portfolio() {
   const { t, i18n } = useTranslation()
@@ -12,14 +14,14 @@ export default function Portfolio() {
   const [selectedProject, setSelectedProject] = useState(null)
 
   const featuredWork = [
-    { title: t('nav.projects'), description: t('featuredWork.projectsDesc'), icon: 'laptop', link: '/projects' },
-    { title: t('nav.skills'), description: t('featuredWork.skillsDesc'), icon: 'code', link: '/skills' },
-    { title: t('nav.experience'), description: t('featuredWork.experienceDesc'), icon: 'briefcase', link: '/experience' },
-    { title: t('nav.creations'), description: t('featuredWork.creationsDesc'), icon: 'palette', link: '/creations' },
-    { title: t('nav.education'), description: t('featuredWork.educationDesc'), icon: 'graduation-cap', link: '/education' },
-    { title: t('nav.hobbies'), description: t('featuredWork.hobbiesDesc'), icon: 'heart', link: '/hobbies' },
-    { title: t('nav.about'), description: t('featuredWork.aboutDesc'), icon: 'user', link: '/about' },
-    { title: t('nav.contact'), description: t('featuredWork.contactDesc'), icon: 'mail', link: '/contact' },
+    { title: t('nav.projects'), description: t('featuredWork.projectsDesc'), icon: <Laptop />, link: '/projects' },
+    { title: t('nav.skills'), description: t('featuredWork.skillsDesc'), icon: <Code />, link: '/skills' },
+    { title: t('nav.experience'), description: t('featuredWork.experienceDesc'), icon: <Briefcase />, link: '/experience' },
+    { title: t('nav.creations'), description: t('featuredWork.creationsDesc'), icon: <Palette />, link: '/creations' },
+    { title: t('nav.education'), description: t('featuredWork.educationDesc'), icon: <GraduationCap />, link: '/education' },
+    { title: t('nav.hobbies'), description: t('featuredWork.hobbiesDesc'), icon: <Heart />, link: '/hobbies' },
+    { title: t('nav.about'), description: t('featuredWork.aboutDesc'), icon: <User />, link: '/about' },
+    { title: t('nav.contact'), description: t('featuredWork.contactDesc'), icon: <Mail />, link: '/contact' },
   ]
 
   const openModal = (project) => {
@@ -38,44 +40,13 @@ export default function Portfolio() {
 
   return (
     <div className="min-h-screen bg-gray-100">
-      <header className="bg-white shadow-sm">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between items-center py-4">
-            <div className="flex items-center">
-              <span className="text-xl font-bold text-gray-800">{t('header.title')}</span>
-            </div>
-            <nav className="hidden md:flex space-x-8">
-              {['Home', 'Projects', 'Skills', 'Experience', 'Creations', 'Education', 'Hobbies', 'About', 'Contact'].map((item) => (
-                <Link
-                  key={item}
-                  to={item === 'Home' ? '/' : `/${item.toLowerCase()}`}
-                  className="text-gray-500 hover:text-gray-900"
-                >
-                  {t(`nav.${item.toLowerCase()}`)}
-                </Link>
-              ))}
-            </nav>
-            <div className="flex items-center">
-              <Globe className="h-5 w-5 text-gray-400 mr-2" />
-              <select
-                onChange={(e) => changeLanguage(e.target.value)}
-                className="bg-white border-gray-300 rounded-md text-gray-700 text-sm"
-              >
-                <option value="en">English</option>
-                <option value="fr">Français</option>
-                <option value="de">Deutsch</option>
-                <option value="zh">中文</option>
-              </select>
-            </div>
-          </div>
-        </div>
-      </header>
+      <Header />
 
       <main className="max-w-7xl mx-auto py-12 px-4 sm:px-6 lg:px-8">
         <div className="bg-white rounded-lg shadow-xl overflow-hidden">
           <div className="md:flex">
             <div className="md:flex-shrink-0">
-              <img className="h-full w-full object-cover md:w-48" src="../src/assets/images/avatars/avatar-homepage.jpeg" alt="Profile" />
+              <img className="h-full w-full object-cover md:w-48" src="https://kydoCode.github.io/portfolio_lv/src/assets/images/avatars/avatar-homepage.jpeg" alt="Profile" />
             </div>
             <div className="p-8">
               <div className="text-sm font-semibold text-blue-600">{t('hero.subtitle')}</div>
@@ -101,7 +72,7 @@ export default function Portfolio() {
                 <div className="p-5">
                   <div className="flex items-center">
                     <div className="flex-shrink-0">
-                      <img src={`/placeholder.svg?text=${item.icon}&width=24&height=24`} alt={item.title} className="h-6 w-6 text-gray-400" />
+                      {item.icon}
                     </div>
                     <div className="ml-5 w-0 flex-1">
                       <dl>
@@ -152,6 +123,8 @@ export default function Portfolio() {
       {modalOpen && selectedProject && (
         <ProjectModal project={selectedProject} onClose={closeModal} />
       )}
+
+      <Footer />
     </div>
   )
 }

--- a/src/pages/Projects.jsx
+++ b/src/pages/Projects.jsx
@@ -28,7 +28,7 @@ export default function Projects() {
         {projectsData.map((project, index) => (
           <div key={index} className="relative">
             <img 
-              src={project.image_path || "/placeholder.svg?height=200&width=300"} 
+              src={project.image_path} 
               alt={project.name} 
               className="hover:opacity-75" 
               onClick={() => openModal(project)} 


### PR DESCRIPTION
Add Header and Footer components, update Portfolio page

* **Header Component**
  - Create `Header` component with navigation links and language selector
  - Import and use `Header` component in `Portfolio.jsx`
* **Footer Component**
  - Create `Footer` component with GitHub and LinkedIn links and credits
  - Import and use `Footer` component in `Portfolio.jsx`
* **Portfolio Page**
  - Remove header elements and replace with `Header` component
  - Add `Footer` component at the bottom of the page
  - Add lucide icons for various sections in the "my professional journey" section