### PR TITLE
Fix display regression by removing forced centering

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -4,7 +4,7 @@ import { Github, Linkedin } from 'lucide-react';
 export default function Footer() {
   return (
     <footer className="bg-gray-800 text-white py-4">
-      <div className="container mx-auto flex justify-between items-center">
+      <div className="flex justify-between items-center">
         <div className="flex items-center space-x-4">
           <a href="https://github.com/kydoCode" target="_blank" rel="noopener noreferrer">
             <Github className="h-6 w-6 text-white" />

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -12,7 +12,7 @@ export default function Header() {
 
   return (
     <header className="bg-white shadow-sm">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div className="px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center py-4">
           <div className="flex items-center">
             <span className="text-xl font-bold text-gray-800">{t('<Dev/>: Code & Coffee')}</span>

--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -22,7 +22,7 @@ export default function About() {
 
   return (
     <div className="min-h-screen bg-gray-100 py-12 px-4 sm:px-6 lg:px-8">
-      <div className="max-w-7xl mx-auto">
+      <div>
         <Header />
         <div className="mt-8">
           <Link to="/" className="text-blue-600 hover:underline">Back to Home</Link>

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -26,7 +26,7 @@ export default function Contact() {
 
   return (
     <div className="min-h-screen bg-gray-100 py-12 px-4 sm:px-6 lg:px-8">
-      <div className="max-w-7xl mx-auto">
+      <div>
         <Header />
         <div className="mt-8">
           <Link to="/" className="text-blue-600 hover:underline">Back to Home</Link>

--- a/src/pages/Portfolio.jsx
+++ b/src/pages/Portfolio.jsx
@@ -52,7 +52,7 @@ export default function Portfolio() {
     <div className="min-h-screen bg-gray-100 flex flex-col items-center">
       <Header />
 
-      <main className="max-w-7xl mx-auto py-12 px-4 sm:px-6 lg:px-8">
+      <main className="py-12 px-4 sm:px-6 lg:px-8">
         <div className="bg-white rounded-lg shadow-xl overflow-hidden">
           <div className="md:flex">
             <div className="md:flex-shrink-0">


### PR DESCRIPTION
Remove forced centering of elements across the site.

* **Header Component**
  - Remove `max-w-7xl mx-auto` from the `div` element in `src/components/Header.jsx`.

* **Footer Component**
  - Remove `container mx-auto` from the `div` element in `src/components/Footer.jsx`.

* **Portfolio Page**
  - Remove `max-w-7xl mx-auto` from the `main` element in `src/pages/Portfolio.jsx`.

* **About Page**
  - Remove `max-w-7xl mx-auto` from the `div` element in `src/pages/About.jsx`.

* **Contact Page**
  - Remove `max-w-7xl mx-auto` from the `div` element in `src/pages/Contact.jsx`.

