### PR TITLE
Update header and footer to match gh-pages

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -3,8 +3,8 @@ import { Github, Linkedin } from 'lucide-react';
 
 export default function Footer() {
   return (
-    <footer className="bg-gray-800 text-white py-4 px-6">
-      <div className="flex justify-between items-center">
+    <footer className="bg-gray-800 text-white py-4 px-6 w-full">
+      <div className="flex justify-between items-center max-w-screen-xl mx-auto">
         <div className="flex items-center space-x-4">
           <a href="https://github.com/kydoCode" target="_blank" rel="noopener noreferrer">
             <Github className="h-6 w-6 text-white" />

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -11,8 +11,8 @@ export default function Header() {
   };
 
   return (
-    <header className="bg-white shadow-sm">
-      <div className="px-4 sm:px-6 lg:px-8">
+    <header className="bg-white shadow-sm w-full">
+      <div className="px-4 sm:px-6 lg:px-8 max-w-screen-xl mx-auto">
         <div className="flex justify-between items-center py-4">
           <div className="flex items-center">
             <Link to="/">

--- a/src/index.css
+++ b/src/index.css
@@ -18,3 +18,9 @@ img:hover {
 .carousel .control-dots {
   margin-top: 1rem;
 }
+
+/* Ensure the header and footer have consistent padding and margin */
+header, footer {
+  padding: 1rem;
+  margin: 0 auto;
+}


### PR DESCRIPTION
Update header and footer components to match the width and display of the deployed version on the GitHub page.

* **Header Component (`src/components/Header.jsx`)**
  - Add `w-full` class to the `header` element to specify full width.
  - Add `max-w-screen-xl mx-auto` classes to the `div` inside the `header` for consistent width.

* **Footer Component (`src/components/Footer.jsx`)**
  - Add `w-full` class to the `footer` element to specify full width.
  - Add `max-w-screen-xl mx-auto` classes to the `div` inside the `footer` for consistent width.

* **CSS Styles (`src/index.css`)**
  - Add CSS rule to ensure the header and footer have consistent padding and margin.

