### PR TITLE
Enhance education cards with clickable links, logos, and improved UI

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -34,3 +34,16 @@ header, footer {
     padding: 0.5rem;
   }
 }
+
+/* Add CSS styles for circle frame around logos */
+.logo-circle {
+  border-radius: 50%;
+  border: 2px solid #ddd;
+  padding: 5px;
+}
+
+/* Add CSS styles for background image on education cards */
+.education-card {
+  background-size: cover;
+  background-position: center;
+}

--- a/src/pages/Education.jsx
+++ b/src/pages/Education.jsx
@@ -15,23 +15,30 @@ export default function Education() {
         <h1 className="text-3xl font-bold mb-4">Education</h1>
         <ul>
           {educationData.education.map((education, index) => (
-            <li key={index} className="mb-2 bg-white shadow-lg rounded-lg p-6">
-              <h2 className="text-xl font-semibold">{education.intitule || 'Unknown Title'}</h2>
-              <p>{education.annees.join(', ') || 'Unknown Year'}</p>
-              {education.etablissement && <p>{education.etablissement}</p>}
-              {education.etablissements && (
-                <ul className="list-disc list-inside mt-2">
-                  {education.etablissements.map((etab, etabIndex) => (
-                    <li key={etabIndex}>
-                      {etab.nom}
-                      {etab.intitule && ` - ${etab.intitule}`}
-                      {etab.mention && ` (${etab.mention})`}
-                    </li>
-                  ))}
-                </ul>
-              )}
-              {education.mention && <p>Mention: {education.mention}</p>}
-            </li>
+            <a href={education.link} target="_blank" rel="noopener noreferrer" key={index}>
+              <li className="mb-2 bg-white shadow-lg rounded-lg p-6 bg-cover bg-center" style={{ backgroundImage: `url(${education.backgroundImage})` }}>
+                <div className="flex items-center">
+                  <img src={education.logo} alt={`${education.intitule} logo`} className="h-12 w-12 rounded-full mr-4" />
+                  <div>
+                    <h2 className="text-xl font-semibold">{education.intitule || 'Unknown Title'}</h2>
+                    <p>{education.annees.join(', ') || 'Unknown Year'}</p>
+                    {education.etablissement && <p>{education.etablissement}</p>}
+                    {education.etablissements && (
+                      <ul className="list-disc list-inside mt-2">
+                        {education.etablissements.map((etab, etabIndex) => (
+                          <li key={etabIndex}>
+                            {etab.nom}
+                            {etab.intitule && ` - ${etab.intitule}`}
+                            {etab.mention && ` (${etab.mention})`}
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                    {education.mention && <p>Mention: {education.mention}</p>}
+                  </div>
+                </div>
+              </li>
+            </a>
           ))}
         </ul>
         <Link to="/" className="text-blue-600 hover:underline mt-4 inline-block">Back to Home</Link>


### PR DESCRIPTION
Make education cards clickable, open links in a new tab, use logos, and improve UI display.

* Wrap each education card in an `a` tag to make it clickable and add `target="_blank"` attribute to open links in a new tab.
* Add logos to each education card using `img` tag and style them with a circle frame using CSS classes.
* Add background image to each education card for better UI display and improve CSS for readability and visual appeal.

