### PR TITLE
Fix education image display in Education.jsx

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -47,3 +47,9 @@ header, footer {
   background-size: cover;
   background-position: center;
 }
+
+/* Add CSS class for education logos to maintain aspect ratio */
+.education-logo {
+  object-fit: cover;
+  border-radius: 50%;
+}

--- a/src/pages/Education.jsx
+++ b/src/pages/Education.jsx
@@ -18,7 +18,7 @@ export default function Education() {
             <a href={education.link} target="_blank" rel="noopener noreferrer" key={index}>
               <li className="mb-2 bg-white shadow-lg rounded-lg p-6 bg-cover bg-center" style={{ backgroundImage: `url(${education.backgroundImage})` }}>
                 <div className="flex items-center">
-                  <img src={education.logo} alt={`${education.intitule} logo`} className="h-12 w-12 rounded-full mr-4" />
+                  <img src={education.logo} alt={`${education.intitule} logo`} className="h-12 w-12 education-logo mr-4" />
                   <div>
                     <h2 className="text-xl font-semibold">{education.intitule || 'Unknown Title'}</h2>
                     <p>{education.annees.join(', ') || 'Unknown Year'}</p>


### PR DESCRIPTION
Fix the display of circle images in `src/pages/Education.jsx` by maintaining the aspect ratio.

* Add a new CSS class `.education-logo` in `src/index.css` to apply `object-fit: cover` and `border-radius: 50%` to images.
* Update the `img` element for educational institution logos in `src/pages/Education.jsx` to use the new `.education-logo` class.

