### PR TITLE
Transform Skills.jsx to accordion for main content

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -109,3 +109,28 @@ header, footer {
     flex-direction: column;
   }
 }
+
+/* Add specific styles for the Radix UI accordion component */
+.radix-accordion__trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem;
+  background-color: #f9f9f9;
+  border: 1px solid #ddd;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  transition: background-color 0.3s ease;
+}
+
+.radix-accordion__trigger:hover {
+  background-color: #f1f1f1;
+}
+
+.radix-accordion__content {
+  padding: 1rem;
+  background-color: #fff;
+  border: 1px solid #ddd;
+  border-radius: 0.5rem;
+  margin-top: 0.5rem;
+}

--- a/src/pages/Skills.jsx
+++ b/src/pages/Skills.jsx
@@ -1,56 +1,48 @@
-import React, { useState } from 'react'
+import React from 'react'
 import { Link } from 'react-router-dom'
-import { ChevronDown, ChevronUp } from 'lucide-react'
+import { Accordion, AccordionItem, AccordionTrigger, AccordionContent } from '@radix-ui/react-accordion'
 import softskillsData from '../data/softskills.json'
 import Header from '../components/Header'
 import Footer from '../components/Footer'
 
 export default function Skills() {
-  const [openSection, setOpenSection] = useState(null)
-
-  const toggleSection = (section) => {
-    setOpenSection(openSection === section ? null : section)
-  }
-
   return (
     <div className="min-h-screen bg-gray-100 p-8 flex flex-col items-center">
       <Header />
       <h1 className="text-3xl font-bold mb-4">Skills</h1>
       <div className="w-full max-w-screen-lg">
-        <h2 className="text-2xl font-semibold mb-2">Technical Skills</h2>
-        {softskillsData.competences.techniques.map((skill, index) => (
-          <div key={index} className="mb-4">
-            <h3 className="text-xl font-semibold cursor-pointer flex items-center justify-between" onClick={() => toggleSection(index)}>
-              {skill.type}
-              {openSection === index ? <ChevronUp className="h-5 w-5" /> : <ChevronDown className="h-5 w-5" />}
-            </h3>
-            {openSection === index && (
-              <ul className="list-disc list-inside bg-white shadow overflow-hidden sm:rounded-lg p-4">
+        <Accordion type="single" collapsible>
+          <h2 className="text-2xl font-semibold mb-2 card">Technical Skills</h2>
+          {softskillsData.competences.techniques.map((skill, index) => (
+            <AccordionItem key={index} value={`item-${index}`}>
+              <AccordionTrigger className="text-xl font-semibold cursor-pointer flex items-center justify-between card">
+                {skill.type}
+              </AccordionTrigger>
+              <AccordionContent className="list-disc list-inside bg-white shadow overflow-hidden sm:rounded-lg p-4">
                 {skill.details.map((detail, detailIndex) => (
                   <li key={detailIndex} className="text-gray-700">{detail}</li>
                 ))}
-              </ul>
-            )}
-          </div>
-        ))}
+              </AccordionContent>
+            </AccordionItem>
+          ))}
+        </Accordion>
       </div>
       <div className="w-full max-w-screen-lg">
-        <h2 className="text-2xl font-semibold mb-2">Transversal Skills</h2>
-        {softskillsData.competences.transversales.map((skill, index) => (
-          <div key={index} className="mb-4">
-            <h3 className="text-xl font-semibold cursor-pointer flex items-center justify-between" onClick={() => toggleSection(index + softskillsData.competences.techniques.length)}>
-              {skill.type}
-              {openSection === index + softskillsData.competences.techniques.length ? <ChevronUp className="h-5 w-5" /> : <ChevronDown className="h-5 w-5" />}
-            </h3>
-            {openSection === index + softskillsData.competences.techniques.length && (
-              <ul className="list-disc list-inside bg-white shadow overflow-hidden sm:rounded-lg p-4">
+        <Accordion type="single" collapsible>
+          <h2 className="text-2xl font-semibold mb-2 card">Transversal Skills</h2>
+          {softskillsData.competences.transversales.map((skill, index) => (
+            <AccordionItem key={index} value={`item-${index + softskillsData.competences.techniques.length}`}>
+              <AccordionTrigger className="text-xl font-semibold cursor-pointer flex items-center justify-between card">
+                {skill.type}
+              </AccordionTrigger>
+              <AccordionContent className="list-disc list-inside bg-white shadow overflow-hidden sm:rounded-lg p-4">
                 {skill.details.map((detail, detailIndex) => (
                   <li key={detailIndex} className="text-gray-700">{detail}</li>
                 ))}
-              </ul>
-            )}
-          </div>
-        ))}
+              </AccordionContent>
+            </AccordionItem>
+          ))}
+        </Accordion>
       </div>
       <div className="mt-8 text-center">
         <Link to="/" className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,7 +5,15 @@ export default {
     "./src/**/*.{js,ts,jsx,tsx}",
   ],
   theme: {
-    extend: {},
+    extend: {
+      card: {
+        backgroundColor: '#fff',
+        borderRadius: '0.5rem',
+        boxShadow: '0 1px 3px rgba(0, 0, 0, 0.1)',
+        padding: '1rem',
+        marginBottom: '1rem',
+      },
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
Transform `src/pages/Skills.jsx` to use Radix UI accordion component for main content.

* Replace custom accordion implementation with Radix UI accordion component.
* Import `Accordion`, `AccordionItem`, `AccordionTrigger`, and `AccordionContent` from `@radix-ui/react-accordion`.
* Update structure to use `Accordion`, `AccordionItem`, `AccordionTrigger`, and `AccordionContent` components.
* Add specific styles for the Radix UI accordion component in `src/index.css`.

