### PR TITLE
Fix Skills section to center content and add logos

### DIFF
--- a/src/components/Accordion.jsx
+++ b/src/components/Accordion.jsx
@@ -1,6 +1,7 @@
 import { Accordion as RadixAccordion, AccordionItem, AccordionTrigger, AccordionContent } from '@radix-ui/react-accordion';
 import { ChevronDownIcon } from '@radix-ui/react-icons';
 import '../index.css';
+import { Html5, Css3, Javascript, ReactLogo, Tailwind, Bootstrap, Php, Mysql, Nodejs, Express, Vuejs, Python, Postgresql, Nosql, Swift, Swiftui, Kanban, Scrum, Trello, Vscode, Xcode, Github, Blackbox, Copilot, Chatgpt, Linters, Figma } from 'lucide-react';
 
 const Accordion = ({ items }) => {
   return (
@@ -14,7 +15,10 @@ const Accordion = ({ items }) => {
           <AccordionContent className="AccordionContent p-4 bg-white border-b border-gray-200" id={`accordion-content-${index}`}>
             <div className="AccordionContentText">
               {item.details.map((detail, detailIndex) => (
-                <li key={detailIndex} className="text-gray-700">{detail}</li>
+                <li key={detailIndex} className="text-gray-700 flex items-center">
+                  {detail.icon}
+                  {detail.text}
+                </li>
               ))}
             </div>
           </AccordionContent>

--- a/src/index.css
+++ b/src/index.css
@@ -261,3 +261,16 @@ h3 {
   height: auto;
   object-fit: cover;
 }
+
+/* Add CSS styles to center the content in the Skills section */
+.skills-section {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+}
+
+/* Add CSS styles to ensure the background remains white when the text is too short to fill the entire width */
+.skills-section .accordion-component {
+  background-color: white;
+}

--- a/src/pages/Skills.jsx
+++ b/src/pages/Skills.jsx
@@ -5,6 +5,7 @@ import softskillsData from '../data/softskills.json'
 import Header from '../components/Header'
 import Footer from '../components/Footer'
 import '../index.css'
+import { Html5, Css3, Javascript, ReactLogo, Tailwind, Bootstrap, Php, Mysql, Nodejs, Express, Vuejs, Python, Postgresql, Nosql, Swift, Swiftui, Kanban, Scrum, Trello, Vscode, Xcode, Github, Blackbox, Copilot, Chatgpt, Linters, Figma } from 'lucide-react'
 
 export default function Skills() {
   const [accordionState, setAccordionState] = useState({});
@@ -28,17 +29,62 @@ export default function Skills() {
     }));
   };
 
+  const getIcon = (skill) => {
+    switch (skill.toLowerCase()) {
+      case 'html': return <Html5 className="h-5 w-5 text-gray-400 mr-2" />;
+      case 'css': return <Css3 className="h-5 w-5 text-gray-400 mr-2" />;
+      case 'javascript': return <Javascript className="h-5 w-5 text-gray-400 mr-2" />;
+      case 'react': return <ReactLogo className="h-5 w-5 text-gray-400 mr-2" />;
+      case 'tailwind css': return <Tailwind className="h-5 w-5 text-gray-400 mr-2" />;
+      case 'bootstrap': return <Bootstrap className="h-5 w-5 text-gray-400 mr-2" />;
+      case 'php': return <Php className="h-5 w-5 text-gray-400 mr-2" />;
+      case 'mysql': return <Mysql className="h-5 w-5 text-gray-400 mr-2" />;
+      case 'node.js': return <Nodejs className="h-5 w-5 text-gray-400 mr-2" />;
+      case 'express.js': return <Express className="h-5 w-5 text-gray-400 mr-2" />;
+      case 'vue.js': return <Vuejs className="h-5 w-5 text-gray-400 mr-2" />;
+      case 'python': return <Python className="h-5 w-5 text-gray-400 mr-2" />;
+      case 'postgresql': return <Postgresql className="h-5 w-5 text-gray-400 mr-2" />;
+      case 'nosql': return <Nosql className="h-5 w-5 text-gray-400 mr-2" />;
+      case 'swift': return <Swift className="h-5 w-5 text-gray-400 mr-2" />;
+      case 'swiftui': return <Swiftui className="h-5 w-5 text-gray-400 mr-2" />;
+      case 'kanban': return <Kanban className="h-5 w-5 text-gray-400 mr-2" />;
+      case 'scrum': return <Scrum className="h-5 w-5 text-gray-400 mr-2" />;
+      case 'trello': return <Trello className="h-5 w-5 text-gray-400 mr-2" />;
+      case 'vs code': return <Vscode className="h-5 w-5 text-gray-400 mr-2" />;
+      case 'xcode': return <Xcode className="h-5 w-5 text-gray-400 mr-2" />;
+      case 'github': return <Github className="h-5 w-5 text-gray-400 mr-2" />;
+      case 'blackbox ai': return <Blackbox className="h-5 w-5 text-gray-400 mr-2" />;
+      case 'copilot': return <Copilot className="h-5 w-5 text-gray-400 mr-2" />;
+      case 'chatgpt': return <Chatgpt className="h-5 w-5 text-gray-400 mr-2" />;
+      case 'linters': return <Linters className="h-5 w-5 text-gray-400 mr-2" />;
+      case 'figma': return <Figma className="h-5 w-5 text-gray-400 mr-2" />;
+      default: return null;
+    }
+  };
+
   return (
-    <div className="min-h-screen bg-gray-100 p-8 flex flex-col items-center">
+    <div className="min-h-screen bg-gray-100 p-8 flex flex-col items-center text-center">
       <Header />
       <h1 className="text-3xl font-bold mb-4">Skills</h1>
       <div className="w-full max-w-screen-lg">
         <h2 className="text-2xl font-semibold mb-2">Hard Skills</h2>
-        <Accordion items={softskillsData.competences.techniques} onChange={handleAccordionChange} className="accordion-component" />
+        <Accordion items={softskillsData.competences.techniques.map(item => ({
+          ...item,
+          details: item.details.map(detail => ({
+            text: detail,
+            icon: getIcon(detail)
+          }))
+        }))} onChange={handleAccordionChange} className="accordion-component" />
       </div>
       <div className="w-full max-w-screen-lg mt-8">
         <h2 className="text-2xl font-semibold mb-2">Soft Skills</h2>
-        <Accordion items={softskillsData.competences.transversales} onChange={handleAccordionChange} className="accordion-component" />
+        <Accordion items={softskillsData.competences.transversales.map(item => ({
+          ...item,
+          details: item.details.map(detail => ({
+            text: detail,
+            icon: getIcon(detail)
+          }))
+        }))} onChange={handleAccordionChange} className="accordion-component" />
       </div>
       <div className="mt-8 text-center">
         <Link to="/" className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700">


### PR DESCRIPTION
Center the content in the Skills section, ensure the background remains white when the text is too short to fill the entire width, and add logos near skills from lucide.

* **Skills.jsx**
  - Import lucide-react icons.
  - Add a function to get the appropriate icon for each skill.
  - Modify the Accordion component to include icons next to skill details.
  - Add `text-center` class to the main container to center the content.

* **index.css**
  - Add CSS styles to center the content in the Skills section.
  - Add CSS styles to ensure the background remains white when the text is too short to fill the entire width.

* **Accordion.jsx**
  - Import lucide-react icons.
  - Modify the Accordion component to include icons next to skill details.

