### PR TITLE
Fix ReferenceError: Html5 is not defined in Skills.jsx

### DIFF
--- a/src/pages/Skills.jsx
+++ b/src/pages/Skills.jsx
@@ -5,7 +5,7 @@ import softskillsData from '../data/softskills.json'
 import Header from '../components/Header'
 import Footer from '../components/Footer'
 import '../index.css'
-// import { Html5, Css3, Javascript, ReactLogo, Tailwind, Bootstrap, Php, Mysql, Nodejs, Express, Vuejs, Python, Postgresql, Nosql, Swift, Swiftui, Kanban, Scrum, Trello, Vscode, Xcode, Github, Copilot, Chatgpt, Linters, Figma } from 'lucide-react'
+import { Html5, Css3, Javascript, ReactLogo, Tailwind, Bootstrap, Php, Mysql, Nodejs, Express, Vuejs, Python, Postgresql, Nosql, Swift, Swiftui, Kanban, Scrum, Trello, Vscode, Xcode, Github, Copilot, Chatgpt, Linters, Figma } from 'lucide-react'
 
 export default function Skills() {
   const [accordionState, setAccordionState] = useState({});


### PR DESCRIPTION
Fix the 'Html5 is not defined' error in `src/pages/Skills.jsx`.

* Uncomment the import statement for `Html5` and other components from 'lucide-react'.
* Ensure the `Html5` component is imported correctly in the import statement.

